### PR TITLE
add safe null to WidgetsBinding 

### DIFF
--- a/lib/src/core/overlay_tooltip_item.dart
+++ b/lib/src/core/overlay_tooltip_item.dart
@@ -39,7 +39,7 @@ class _OverlayTooltipItemImplState extends State<OverlayTooltipItemImpl> {
   }
 
   void _addToPlayableWidget() {
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+    WidgetsBinding?.instance?.addPostFrameCallback((timeStamp) {
       try {
         OverlayTooltipScaffold.of(context)?.addPlayableWidget(
             OverlayTooltipModel(


### PR DESCRIPTION
add safe null to WidgetsBinding   because it is potentially null
