### PR TITLE
Fix Nullable WidgetsBinding

### DIFF
--- a/lib/src/core/overlay_tooltip_item.dart
+++ b/lib/src/core/overlay_tooltip_item.dart
@@ -39,7 +39,7 @@ class _OverlayTooltipItemImplState extends State<OverlayTooltipItemImpl> {
   }
 
   void _addToPlayableWidget() {
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
       try {
         OverlayTooltipScaffold.of(context)?.addPlayableWidget(
             OverlayTooltipModel(


### PR DESCRIPTION
Fix this issue:
`Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.`