### PR TITLE
Add an optional `absorbPointer` flag to the OverlayTooltipItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ OverlayTooltipScaffold(
 ```
 
 This widget can be instantiated with the following parameters:
+- **ignorePointer** (optional) - `true` by default. Controls whether the wrapped widget is clickable or not.
+
 - **displayIndex** - This ensures the order in which the tooltips are displayed
 
 - **tooltip** - This is a widget function that exposes the controller and can be used to create a custom widget to display as the tooltip.

--- a/lib/src/core/overlay_tooltip_item.dart
+++ b/lib/src/core/overlay_tooltip_item.dart
@@ -4,6 +4,7 @@ import '../impl.dart';
 import '../model/tooltip_widget_model.dart';
 
 abstract class OverlayTooltipItemImpl extends StatefulWidget {
+  final bool absorbPointer;
   final Widget child;
   final Widget Function(TooltipController) tooltip;
   final TooltipVerticalPosition tooltipVerticalPosition;
@@ -12,6 +13,7 @@ abstract class OverlayTooltipItemImpl extends StatefulWidget {
 
   OverlayTooltipItemImpl(
       {Key? key,
+      required this.absorbPointer,
       required this.displayIndex,
       required this.child,
       required this.tooltip,
@@ -43,6 +45,7 @@ class _OverlayTooltipItemImplState extends State<OverlayTooltipItemImpl> {
       try {
         OverlayTooltipScaffold.of(context)?.addPlayableWidget(
             OverlayTooltipModel(
+                absorbPointer: widget.absorbPointer,
                 child: widget.child,
                 tooltip: widget.tooltip,
                 widgetKey: widgetKey,

--- a/lib/src/core/overlay_tooltip_scaffold.dart
+++ b/lib/src/core/overlay_tooltip_scaffold.dart
@@ -139,7 +139,8 @@ class _TooltipLayout extends StatelessWidget {
             left: topLeft.dx,
             bottom: size.maxHeight - bottomRight.dy,
             right: size.maxWidth - bottomRight.dx,
-            child: AbsorbPointer(child: model.child),
+            child: AbsorbPointer(
+                child: model.child, absorbing: model.absorbPointer),
           ),
           _buildToolTip(topLeft, bottomRight, size)
         ],

--- a/lib/src/impl.dart
+++ b/lib/src/impl.dart
@@ -65,6 +65,8 @@ class OverlayTooltipScaffold extends OverlayTooltipScaffoldImpl {
 }
 
 class OverlayTooltipItem extends OverlayTooltipItemImpl {
+  final bool absorbPointer;
+
   final Widget child;
 
   /// The tooltip widget to be displayed with the main widget
@@ -85,6 +87,7 @@ class OverlayTooltipItem extends OverlayTooltipItemImpl {
 
   OverlayTooltipItem(
       {Key? key,
+      this.absorbPointer = true,
       required this.displayIndex,
       required this.child,
       required this.tooltip,
@@ -92,6 +95,7 @@ class OverlayTooltipItem extends OverlayTooltipItemImpl {
       this.tooltipHorizontalPosition = TooltipHorizontalPosition.WITH_WIDGET})
       : super(
             key: key,
+            absorbPointer: absorbPointer,
             child: child,
             displayIndex: displayIndex,
             tooltip: tooltip,

--- a/lib/src/model/tooltip_widget_model.dart
+++ b/lib/src/model/tooltip_widget_model.dart
@@ -3,6 +3,7 @@ import 'package:overlay_tooltip/src/constants/enums.dart';
 import '../impl.dart';
 
 class OverlayTooltipModel {
+  final bool absorbPointer;
   final Widget child;
   final Widget Function(TooltipController) tooltip;
   final GlobalKey widgetKey;
@@ -11,7 +12,8 @@ class OverlayTooltipModel {
   final int displayIndex;
 
   OverlayTooltipModel(
-      {required this.child,
+      {required this.absorbPointer,
+      required this.child,
       required this.tooltip,
       required this.widgetKey,
       required this.vertPosition,

--- a/test/tooltip_controller_test.dart
+++ b/test/tooltip_controller_test.dart
@@ -89,6 +89,7 @@ void main() {
 
 OverlayTooltipModel overlayTooltipModel(int displayIndex) =>
     OverlayTooltipModel(
+        absorbPointer: true,
         child: Container(),
         tooltip: (cont) => Container(),
         widgetKey: GlobalKey(),


### PR DESCRIPTION
First of all, thanks for the amazing package! I hope you'll accept this small change that enables the `OverlayTooltipItem` to become clickable.

I see at least 2 use cases for this feature:

1. It's useful to allow a user to click on whatever item the tooltip is for to perform the action immediately.
2. Even if we don't want to allow the action immediately, it's useful to at least have an ability to react to gestures on the wrapped item (for example to jump to another tooltip or dismiss the tooltips).

Currently, the `AbsorbPointer()` wrapper around the `child` prevents all this.